### PR TITLE
Grid Class Renaming

### DIFF
--- a/Framework Source/SCSS/_settings.scss
+++ b/Framework Source/SCSS/_settings.scss
@@ -14,12 +14,39 @@
 
 $default-font: inherit;
 $default-space: 16px !default;
+$default-font-size: 16px;
 
 //
 // 2. Grid
 //
 
 $scope: '' !default;
+
+$grid-classes: (
+  grid: $scope + 'grid',
+  row: $scope + 'row',
+  column: $scope + 'column'
+) !default;
+
+$grid-widths: (
+  fluid: 100%,
+  narrow: 768px,
+  wide: 1200px
+) !default;
+
+$grid-sections: (
+  small: 48px,
+  medium: 96px,
+  large: 144px
+) !default;
+
+$breakpoints: (
+  $scope + xsmall: 0,
+  $scope + small: 576px,
+  $scope + medium: 768px,
+  $scope + large: 992px,
+  $scope + xlarge: 1200px
+) !default;
 
 $column-offset-classes: true;
 $column-order-classes: true;
@@ -32,32 +59,6 @@ $column-bottom-padding-space: $default-space;
 $column-gutter-space: $default-space / 2;
 $grid-space: $default-space;
 
-$grid-classes: (
-    grid: $scope + 'grid',
-     row: $scope + 'row',
-  column: $scope + 'column'
-) !default;
-
-$breakpoints: (
-  $scope + xsmall: 0,
-   $scope + small: 576px,
-  $scope + medium: 768px,
-   $scope + large: 992px,
-  $scope + xlarge: 1200px
-) !default;
-
-$grid-widths: (
-   $scope + fluid: 100%,
-  $scope + narrow: 768px,
-    $scope + wide: 1200px
-) !default;
-
-$grid-sections: (
-   $scope + small: 48px,
-  $scope + medium: 96px,
-   $scope + large: 144px
-) !default;
-
 //
 // 3. Buttons
 //
@@ -69,28 +70,28 @@ $button-border-radius: 0;
 $button-border-style: solid;
 $button-border-width: 0;
 $button-box-shadow: none;
-$button-font-size: 16px;
-$button-font: 16px;
+$button-font-size: $default-font-size;
+$button-font: $default-font;
 $button-letter-spacing: 0;
 $button-margin: 0;
 $button-padding: 12px $default-space;
 $button-text-color: inherit;
 $button-text-decoration: none;
 
-$buttons: (
-  $scope + small: (
+$button-sizes: (
+  small: (
     padding: 10px 14px,
     font-size: 14px
   ),
-  $scope + medium: (
+  medium: (
     padding: 12px 16px,
     font-size: 16px
   ),
-  $scope + large: (
+  large: (
     padding: 16px 20px,
     font-size: 20px
   ),
-  $scope + huge: (
+  huge: (
     padding: 22px 28px,
     font-size: 24px
   )
@@ -101,14 +102,14 @@ $buttons: (
 //
 
 $avatar-sizes: (
-  small: 2.5rem,
-  medium: 3.75rem,
-  large: 5r
+  small: 40px,
+  medium: 54px,
+  large: 80px
 
 $avatar-badge-sizes: (
-  small: 0.9375rem,
-  medium: 1.15rem,
-  large: 1.5rem
+  small: 15px,
+  medium: 18px,
+  large: 24px
 );
 
 $avatar-badge-colors: (

--- a/Framework Source/SCSS/_settings.scss
+++ b/Framework Source/SCSS/_settings.scss
@@ -52,12 +52,12 @@ $column-offset-classes: true;
 $column-order-classes: true;
 
 $columns: 12 !default;
-$grid-default-width: 992px !default;
+$grid-width: 992px !default;
 $order-threshold: 20 !default;
 
-$column-bottom-padding-space: $default-space;
-$column-gutter-space: $default-space / 2;
-$grid-space: $default-space;
+$column-padding-bottom: $default-space;
+$column-gutter: $default-space / 2;
+$grid-gutter: $default-space;
 
 //
 // 3. Buttons

--- a/Framework Source/SCSS/_settings.scss
+++ b/Framework Source/SCSS/_settings.scss
@@ -25,17 +25,17 @@ $column-offset-classes: true;
 $column-order-classes: true;
 
 $columns: 12 !default;
-$container-default-width: 992px !default;
+$grid-default-width: 992px !default;
 $order-threshold: 20 !default;
 
 $column-bottom-padding-space: $default-space;
 $column-gutter-space: $default-space / 2;
-$container-space: $default-space;
+$grid-space: $default-space;
 
 $grid-classes: (
-  container: $scope + 'container',
-        row: $scope + 'row',
-     column: $scope + 'column'
+    grid: $scope + 'grid',
+     row: $scope + 'row',
+  column: $scope + 'column'
 ) !default;
 
 $breakpoints: (
@@ -46,13 +46,13 @@ $breakpoints: (
   $scope + xlarge: 1200px
 ) !default;
 
-$container-widths: (
+$grid-widths: (
    $scope + fluid: 100%,
   $scope + narrow: 768px,
     $scope + wide: 1200px
 ) !default;
 
-$container-sections: (
+$grid-sections: (
    $scope + small: 48px,
   $scope + medium: 96px,
    $scope + large: 144px

--- a/Framework Source/SCSS/_settings.scss
+++ b/Framework Source/SCSS/_settings.scss
@@ -23,9 +23,9 @@ $default-font-size: 16px;
 $scope: '' !default;
 
 $grid-classes: (
-  grid: $scope + 'grid',
-  row: $scope + 'row',
-  column: $scope + 'column'
+  grid: 'grid',
+  row: 'row',
+  column: 'column'
 ) !default;
 
 $grid-widths: (

--- a/Framework Source/SCSS/components/button/_utilities.scss
+++ b/Framework Source/SCSS/components/button/_utilities.scss
@@ -2,7 +2,7 @@
 
   // Sizes
 
-  @each $name in $buttons {
+  @each $name in $button-sizes {
     $size: nth($name, 1);
     &.#{$scope}#{$size} {
       padding: map-deep-get($buttons, $size, padding);

--- a/Framework Source/SCSS/components/grid/_grid.scss
+++ b/Framework Source/SCSS/components/grid/_grid.scss
@@ -1,8 +1,8 @@
 // Selector variables
 
-$grid: map-get($grid-classes, grid);
-$row: map-get($grid-classes, row);
-$column: map-get($grid-classes, column);
+$grid: $scope + map-get($grid-names, grid);
+$row: $scope + map-get($grid-names, row);
+$column: $scope + map-get($grid-names, column);
 
 // Grid
 

--- a/Framework Source/SCSS/components/grid/_grid.scss
+++ b/Framework Source/SCSS/components/grid/_grid.scss
@@ -62,7 +62,7 @@ $column: $scope + map-get($grid-names, column);
 //
 
 @each $break in $breakpoints {
-  $size: nth($name, 1); // take only the name of the breakpoint, NOT its value.
+  $size: nth($break, 1); // take only the name of the breakpoint, NOT its value.
 
   @include breakpoint-up($size) {
     @for $i from 1 through $columns {

--- a/Framework Source/SCSS/components/grid/_grid.scss
+++ b/Framework Source/SCSS/components/grid/_grid.scss
@@ -1,15 +1,15 @@
 // Selector variables
 
-$container: map-get($grid-classes, container);
+$grid: map-get($grid-classes, grid);
 $row: map-get($grid-classes, row);
 $column: map-get($grid-classes, column);
 
-// Container
+// Grid
 
-.#{$container}::before,
-.#{$container}::after,
-.#{$container} .#{$row}::before,
-.#{$container} .#{$row}::after,
+.#{$grid}::before,
+.#{$grid}::after,
+.#{$grid} .#{$row}::before,
+.#{$grid} .#{$row}::after,
 .#{$row} .#{$column}::before, .#{$row} .#{$column}::after,
 .#{$row} .#{$column}s::before, .#{$row} .#{$column}s::after {
   display: block;
@@ -19,13 +19,13 @@ $column: map-get($grid-classes, column);
   margin: 0;
 }
 
-.#{$container} {
+.#{$grid} {
   box-sizing: border-box;
   display: flex;
   margin: 0 auto;
-  max-width: $container-default-width;
-  padding-left: $container-space;
-  padding-right: $container-space;
+  max-width: $grid-default-width;
+  padding-left: $grid-space;
+  padding-right: $grid-space;
   position: relative;
 }
 

--- a/Framework Source/SCSS/components/grid/_grid.scss
+++ b/Framework Source/SCSS/components/grid/_grid.scss
@@ -23,9 +23,9 @@ $column: $scope + map-get($grid-names, column);
   box-sizing: border-box;
   display: flex;
   margin: 0 auto;
-  max-width: $grid-default-width;
-  padding-left: $grid-space;
-  padding-right: $grid-space;
+  max-width: $grid-width;
+  padding-left: $grid-gutter;
+  padding-right: $grid-gutter;
   position: relative;
 }
 
@@ -47,9 +47,9 @@ $column: $scope + map-get($grid-names, column);
   max-width: 100%;
   min-height: 1px;
   min-width: 0;
-  padding-bottom: $column-bottom-padding-space;
-  padding-left: $column-gutter-space;
-  padding-right: $column-gutter-space;
+  padding-bottom: $column-bottom-padding;
+  padding-left: $column-gutter;
+  padding-right: $column-gutter;
   word-wrap: break-word;
 
   @if $column-order-classes == true {
@@ -61,25 +61,25 @@ $column: $scope + map-get($grid-names, column);
 // Grid, offset, and order classes generator
 //
 
-@each $name in $breakpoints {
-  $break: nth($name, 1); // take only the name of the breakpoint, NOT its value.
+@each $break in $breakpoints {
+  $size: nth($name, 1); // take only the name of the breakpoint, NOT its value.
 
-  @include breakpoint-up($break) {
+  @include breakpoint-up($size) {
     @for $i from 1 through $columns {
 
-      .#{$break}-#{$i} {
+      .#{$size}-#{$i} {
         flex: 0 0 percentage($i / $columns);
         max-width: percentage($i / $columns);
       }
 
       @if $column-offset-classes == true {
-        .#{$break}-offset-#{$i} {
+        .#{$size}-offset-#{$i} {
           margin-left: percentage($i / $columns);
         }
       }
 
       @if $column-order-classes == true {
-        .#{$break}-order-#{$i} {
+        .#{$size}-order-#{$i} {
           order: $i;
         }
       }

--- a/Framework Source/SCSS/components/grid/_utilities.scss
+++ b/Framework Source/SCSS/components/grid/_utilities.scss
@@ -15,7 +15,7 @@
   // 1. Grid widths
 
   @each $name, $width in $grid-widths {
-    &.#{$name} {
+    &.#{$scope}#{$name} {
       max-width: $width;
     }
   }
@@ -23,7 +23,7 @@
   // 2. Grid sections
 
   @each $name, $padding in $grid-sections {
-    &.#{$name}-section {
+    &.#{$scope}#{$name}-section {
       padding-top: $padding;
       padding-bottom: $padding;
     }

--- a/Framework Source/SCSS/components/grid/_utilities.scss
+++ b/Framework Source/SCSS/components/grid/_utilities.scss
@@ -2,34 +2,34 @@
 //
 // Utilities
 //
-// 1. Container widths
-// 2. Container sections
-// 3. Container fullscreen
-// 4. Container fullscreen align classes
+// 1. Grid widths
+// 2. Grid sections
+// 3. Grid fullscreen
+// 4. Grid fullscreen align classes
 // 5. Column collapsing
 //
 // ------------------------------ *
 
-.#{$container} {
+.#{$grid} {
 
-  // 1. Container widths
+  // 1. Grid widths
 
-  @each $name, $width in $container-widths {
+  @each $name, $width in $grid-widths {
     &.#{$name} {
       max-width: $width;
     }
   }
 
-  // 2. Container sections
+  // 2. Grid sections
 
-  @each $name, $padding in $container-sections {
+  @each $name, $padding in $grid-sections {
     &.#{$name}-section {
       padding-top: $padding;
-      padding-bottom: $padding; 
+      padding-bottom: $padding;
     }
   }
 
-  // 3. Container fullscreen and align classes
+  // 3. Grid fullscreen and align classes
 
   .#{$scope}fullscreen {
     box-sizing: border-box;
@@ -41,7 +41,7 @@
       flex: 1 1 auto;
     }
 
-    // 4. Container fullscreen align classes
+    // 4. Grid fullscreen align classes
 
     .#{$row} {
       &.#{$scope}align-bottom {

--- a/Framework Source/SCSS/helpers/_media_queries.scss
+++ b/Framework Source/SCSS/helpers/_media_queries.scss
@@ -1,5 +1,4 @@
 // Breakpoint Mixins
-//
 // NOTE: "breakpoint-up" is used to generate grid classes.
 
 @mixin breakpoint-up($size) {


### PR DESCRIPTION
- Makes naming not gross in _settings
- Gives sensible names to classes: Grid, Row, Container
- Gives sensible names to variables: gutters, padding, etc.